### PR TITLE
Add C++ version check to char16 definition

### DIFF
--- a/include/rosidl_dynamic_typesupport/uchar.h
+++ b/include/rosidl_dynamic_typesupport/uchar.h
@@ -19,14 +19,15 @@
 extern "C" {
 #endif
 
-
-#if defined __has_include
-#  if __has_include(<uchar.h>)
-#    include <uchar.h>
-#    define INCLUDED_UCHAR 1
-#  endif
-#endif
-#if !defined(INCLUDED_UCHAR) && __cplusplus <= 199711L
+#if defined(__cplusplus) && __cplusplus >= 201103L
+// Nothing to do here, C++11 and beyond have char16_t as a keyword:
+// https://en.cppreference.com/w/cpp/keyword/char16_t
+#elif defined(__has_include) && __has_include(<uchar.h>)
+// If the compiler has __has_include, and uchar.h exists, include that as it will have char16_t
+// as a typedef.
+#  include <uchar.h>
+#else
+// Otherwise assume that char16_t isn't defined anywhere, and define it ourselves as uint_least16_t.
 #  include <stdint.h>
 typedef uint_least16_t char16_t;
 #endif

--- a/include/rosidl_dynamic_typesupport/uchar.h
+++ b/include/rosidl_dynamic_typesupport/uchar.h
@@ -26,7 +26,7 @@ extern "C" {
 #    define INCLUDED_UCHAR 1
 #  endif
 #endif
-#if !defined(INCLUDED_UCHAR)
+#if !defined(INCLUDED_UCHAR) && __cplusplus <= 199711L
 #  include <stdint.h>
 typedef uint_least16_t char16_t;
 #endif


### PR DESCRIPTION
This definition is problematic for C++ compilers using C++11 or superior as `char16_t` becomes a builtin type, leading to the [following error](https://github.com/micro-ROS/micro_ros_mbed/actions/runs/4655908030/jobs/8239009724#step:5:1350):

```
/__w/micro_ros_mbed/micro_ros_mbed/micro_ros_mbed/include/rosidl_dynamic_typesupport/rosidl_dynamic_typesupport/uchar.h:31:24: error: redeclaration of C++ built-in type 'char16_t' [-fpermissive]
   31 | typedef uint_least16_t char16_t;
```

This PR adds a check for C++ version used, avoiding the type definition for C++11 and upper versions.