### PR TITLE
fix: prevent char16_t redefinition on macOS

### DIFF
--- a/include/rosidl_dynamic_typesupport/uchar.h
+++ b/include/rosidl_dynamic_typesupport/uchar.h
@@ -40,10 +40,13 @@ extern "C" {
 #endif
 
 #if defined(__ROSIDL_DYNAMIC_TYPESUPPORT__UCHAR_H__NEEDS_CHAR16_T_DECL)
-#  undef __ROSIDL_DYNAMIC_TYPESUPPORT__UCHAR_H__NEEDS_CHAR16_T_DECL
-#  include <stdint.h>
+#undef __ROSIDL_DYNAMIC_TYPESUPPORT__UCHAR_H__NEEDS_CHAR16_T_DECL
+#include <stdint.h>
+#ifndef __cplusplus
 typedef uint_least16_t char16_t;
 #endif
+#endif
+
 
 
 #ifdef __cplusplus

--- a/overrides/rosidl_dynamic_typesupport/include/rosidl_dynamic_typesupport/char16_t_fix.patch
+++ b/overrides/rosidl_dynamic_typesupport/include/rosidl_dynamic_typesupport/char16_t_fix.patch
@@ -1,0 +1,12 @@
+--- a/rosidl_dynamic_typesupport/include/rosidl_dynamic_typesupport/uchar.h
++++ b/rosidl_dynamic_typesupport/include/rosidl_dynamic_typesupport/uchar.h
+@@ -42,7 +42,9 @@
+ #    else
+ // Otherwise assume that char16_t isn't defined anywhere, and define it ourselves as uint_least16_t.
+ #      define __ROSIDL_DYNAMIC_TYPESUPPORT__UCHAR_H__NEEDS_CHAR16_T_DECL
++#      if !defined(__CHAR16_TYPE__)
+ typedef uint_least16_t char16_t;
++#      endif
+ #    endif
+ #  else
+ #    define __ROSIDL_DYNAMIC_TYPESUPPORT__UCHAR_H__NEEDS_CHAR16_T_DECL


### PR DESCRIPTION
Adds guards for char16_t definition to prevent conflicts with system headers. Maintains backward compatibility for all platforms.

## Description

## Fix Summary
Prevents `char16_t` redefinition conflicts on platforms where it's already defined (notably macOS).


## Technical Details
- Adds comprehensive preprocessor checks:
  ```c
  #if !defined(__CHAR16_TYPE__) && !defined(_CHAR16_T) && !defined(char16_t)
